### PR TITLE
Added OSX prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ Motivation
 A good starting point for web apps styled with [material design](http://www.google.com/design/spec/material-design/introduction.html), but also to experiment with
 [React Style](https://github.com/SanderSpies/react-style/) and see what works and what doesn't.
 
+OSX Prerequisites
+---
+- install [Homebrew](http://brew.sh)
+- brew install librsvg pkg-config
+
 Run
 ---
 - git clone https://github.com/SanderSpies/react-material.git


### PR DESCRIPTION
These are needed in order to install node-rsvg. Otherwise npm install fails.
