### PR TITLE
Added gulp taskrunner: lint, browser-sync, webpack.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,60 @@
+'use strict';
+var gulp = require('gulp'),
+    react = require('gulp-react'),
+    clean = require('gulp-clean'),
+    gjslint = require('gulp-gjslint'),
+    sync = require('browser-sync'),
+    webpack = require('gulp-webpack');
+
+var paths = {
+  src: [
+    './components/*.js',
+    './style/*.js',
+    './themes/*.js',
+    './views/*.js'
+  ],
+  packed: [
+    './assets/bundle.js',
+    './assets/styles.css'
+  ]
+
+};
+
+gulp.task('pack', function() {
+  return gulp.src('./views/DocumentationApplication.js')
+    .pipe(webpack(require('./webpack.config.js')))
+      .pipe(gulp.dest('assets/'));
+});
+
+gulp.task('sync', ['pack'], function(cb) {
+  sync({
+    server: {
+      baseDir: './',
+      index: './index.html'
+    },
+    files: [
+      './index.html',
+      './assets/bundle.js',
+      './assets/styles.css'
+    ],
+    port: 9000,
+    open: true
+  }, function() {
+    cb();
+  });
+});
+
+gulp.task('watch', function() {
+  gulp.watch(paths.src, ['pack']);
+});
+
+gulp.task('lint', function() {
+  return gulp.src(paths.src)
+    .pipe(react())
+    .pipe(gulp.dest('./assets'))
+    .pipe(gjslint({ flags: ['--nojsdoc'] }))
+    .pipe(gjslint.reporter('console'))
+    .pipe(clean());
+});
+
+gulp.task('default', ['pack', 'sync', 'watch']);

--- a/package.json
+++ b/package.json
@@ -1,16 +1,24 @@
 {
   "name": "react-material",
   "version": "0.0.2-alpha",
-  "keywords": ["react-component"],
+  "keywords": [
+    "react-component"
+  ],
   "devDependencies": {
+    "browser-sync": "^1.4.0",
     "css-loader": "^0.7.0",
     "extract-text-webpack-plugin": "git+https://github.com/andreypopp/extract-text-webpack-plugin.git",
     "file-loader": "^0.6.1",
+    "gulp": "^3.8.8",
+    "gulp-clean": "^0.3.1",
+    "gulp-gjslint": "^0.1.2",
+    "gulp-react": "^1.0.1",
+    "gulp-webpack": "^0.3.0",
+    "html-loader": "0.2.2",
     "jsx-loader": "^0.11.0",
-    "style-loader": "^0.6.4",
-    "webpack": "^1.3.3-beta1",
     "react-style": "0.0.13-alpha",
-    "html-loader": "0.2.2"
+    "style-loader": "^0.6.4",
+    "webpack": "^1.3.3-beta1"
   },
   "dependencies": {
     "react": "0.11.1",


### PR DESCRIPTION
default: Packs components, runs Browser-sync, and watches for
    file changes. On file changes, reloads all connected browsers.
lint: Runs Google Closure Linter on each file after
    transforming the jsx files.
Note: Due to the way the linter currently works, temporary files
need to be created after compiling with gulp-react and then
deleting them after linting. Because of this, file paths outputted by the linter
are not the correct ones.
