### PR TITLE
Add support for using react-material with browserify

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,5 +24,10 @@
   "peerDependencies": {
     "react": "^0.12.0",
     "react-style": "^0.3.0"
+  },
+  "browserify" : {
+    "transform" : [
+	  ["reactify", {"es6": true}]
+    ]
   }
 }


### PR DESCRIPTION
Process component .js files (which are really JSX rather than JS)
with reactify.

This is also required to ES5-ify certain JS harmony features
used.
