### PR TITLE
Fix draggable clickable elements (e.g. buttons, list items)

### DIFF
--- a/components/RippleContainer.js
+++ b/components/RippleContainer.js
@@ -48,7 +48,8 @@ var RippleContainer = React.createClass({
 
   getInitialState() {
     return {
-      ripples: []
+      ripples: [],
+      hasMouseMoved: false
     };
   },
 
@@ -79,8 +80,10 @@ var RippleContainer = React.createClass({
     return <div styles={[styles.normalStyle, props.styles]}
         onTouchStart={isTouchDevice && this.onMouseDown}
         onTouchEnd={isTouchDevice && this.onMouseUp}
+        onTouchMove={isTouchDevice && this.onMouseMove}
         onTouchCancel={isTouchDevice && this.onMouseLeave}
         onMouseDown={!isTouchDevice && this.onMouseDown}
+        onMouseMove={!isTouchDevice && this.onMouseMove}
         onMouseLeave={!isTouchDevice && this.onMouseLeave}
         onMouseUp={!isTouchDevice && this.onMouseUp}
       >
@@ -114,14 +117,19 @@ var RippleContainer = React.createClass({
 
     // messes up click event :-(
     this.setState({ripples: ripples});
+    this.setState({hasMouseMoved: false});
 
     setTimeout(this.startRipple, 0);
+  },
+
+  onMouseMove(e) {
+    this.setState({hasMouseMoved: true});
   },
 
   onMouseUp(e) {
     this.onMouseLeave();
     var onClick = this.props.onClick;
-    if (onClick) {
+    if (onClick && !this.state.hasMouseMoved) {
       e.preventDefault();
       onClick({target: this.getDOMNode().parentNode, originalEvent: e});
     }


### PR DESCRIPTION
Related to #15

I have a scrollable List with clickable ListItems in it. Previously when I scrolled the list on a touch device, the onClick handler of a list item was triggered. Not anymore.

I wasn't sure about how to best tackle this, so this is a very simple patch that uses state to keep track of whether any mouseMove events occurred before the mouseUp. If yes, then we won't call the onClick handler.
A way to improve on this would be keeping track of the cursor position (should it also be done with state?) and suppressing the onClick only if distance moved is greater than e.g. 4px.
Let me know if you have any suggestions, etc.
