### PR TITLE
Appbar improvements

### DIFF
--- a/components/AppBar.js
+++ b/components/AppBar.js
@@ -78,6 +78,7 @@ var AppBar = React.createClass({
     onBackButtonClick: React.PropTypes.func,
     onMenuButtonCLick: React.PropTypes.func,
     onNavButtonClick: React.PropTypes.func,
+    onTitleClick: React.PropTypes.func,
     title: React.PropTypes.string
   },
 
@@ -115,8 +116,13 @@ var AppBar = React.createClass({
         <Icon icon="menu"/>
       </div>
       }
+    {props.onBackButtonClick &&
+      <div styles={styles.navButtonStyle} onClick={props.onBackButtonClick}>
+        <Icon icon="arrow-back"/>
+      </div>
+      }
     {props.title &&
-      <div styles={[Typography.title, styles.titleStyle, expandedTitleStyle, headLineStyle, propsStyles.titleStyle]}>
+      <div styles={[Typography.title, styles.titleStyle, expandedTitleStyle, headLineStyle, propsStyles.titleStyle]} onClick={props.onTitleClick}>
         {props.title}
       </div>
       }


### PR DESCRIPTION
- Make back button work - it's shown when `onBackButtonClick` property is given (same as nav button).
- Add optional `onTitleClick` property.
- In `checkExpanded()`, ensure the component is still mounted before trying to do state changes.

Note that there's also unused `onMenuButtonCLick` property (also note the typo in "click"), I didn't do anything with it since it's unclear to me how it's different from nav button. Should it be removed?
