### PR TITLE
Make TextField value handling match React.DOM.input value handling

### DIFF
--- a/components/TextField.js
+++ b/components/TextField.js
@@ -160,8 +160,6 @@ var TextField = React.createClass({
       // a flag set when the user initiates focusing the
       // text field and then cleared a moment later
       focusing: true,
-      // the current value of the input field
-      value: ''
     };
   },
 


### PR DESCRIPTION
Make the way TextField handles setting its value match the way
React.DOM.input and other form controls work.

If props.value is supplied, then the component is a 'controlled'
component and its value always matches props.value, otherwise
it is an uncontrolled component whose initial value is
props.defaultValue.
