### PR TITLE
Fix bugs preventing webpack build completing.

### DIFF
--- a/components/src/Application.js
+++ b/components/src/Application.js
@@ -1,6 +1,7 @@
 'use strict';
 
-import {StyleSheet} from '../style/';
+import React from 'react';
+import StyleSheet from 'react-style';
 
 export default class Application extends React.Component {
 

--- a/views/src/DocumentationApplication.js
+++ b/views/src/DocumentationApplication.js
@@ -1,6 +1,6 @@
 'use strict';
 
-require("./style.css");
+// require("./style.css");
 
 import React from 'react';
 import StyleSheet from 'react-style';


### PR DESCRIPTION
DocumentationApplication.js was requiring a style sheet that wasn't there (commented out for now). Application.js was importing react-style incorrectly. 