### PR TITLE
README: add jscissr/react-polymer to alternatives

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Current issues
 Alternatives
 ---
 - https://github.com/callemall/material-ui
+- https://github.com/jscissr/react-polymer
 
 If there are others let us know.
 


### PR DESCRIPTION
This projects lets you use the official Polymer implementation of Material, in React.
